### PR TITLE
add facebook oauth. Fix: facebook doesnt guarantee the return of emai…

### DIFF
--- a/server/auth/facebook/passport.js
+++ b/server/auth/facebook/passport.js
@@ -18,7 +18,8 @@ exports.setup = function (User, config) {
         if (!user) {
           user = new User({
             name: profile.displayName,
-            email: profile.emails[0].value,
+            // email: profile.emails[0].value,
+            email: profile.id,
             role: 'user',
             username: profile.username,
             provider: 'facebook',


### PR DESCRIPTION
…l, which was discovered after some trail and error and research.  the application will use the FB id in place of email.
